### PR TITLE
fix package.json name and main path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@target-corp/react-native-svg-parser",
+  "name": "react-native-svg-parser",
   "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-svg-parser",
   "version": "1.0.5",
   "description": "parses SVG/XML format and converts to react-native-svg elements",
-  "main": "lib/parser.js",
+  "main": "src/parser.js",
   "scripts": {
     "lint": "standard",
     "lint-fix": "standard --fix",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@target-corp/react-native-svg-parser",
+  "name": "react-native-svg-parser",
   "version": "1.0.5",
   "description": "parses SVG/XML format and converts to react-native-svg elements",
   "main": "lib/parser.js",


### PR DESCRIPTION
Hi.
Fixed an issue that could not be imported properly because package.json's main path was incorrect when installing with yarn.
At the same time, I changed the name to a meaningful name, but if there is particular attention regarding this, I will return it.