### PR TITLE
Use SVG height and width to calculate ViewBox

### DIFF
--- a/src/__tests__/fixtures.test.js
+++ b/src/__tests__/fixtures.test.js
@@ -84,4 +84,12 @@ const SVG_WITH_UNMAPPED_ELEMENTS = `<?xml version="1.0" encoding="UTF-8"?>
 </svg>
 `
 
-export {SIMPLE_CSS, SIMPLE_SVG, SVG_WITH_UNMAPPED_ELEMENTS}
+const SVG_WITH_WIDTH_AND_HEIGHT_BUT_NO_VIEWPORT = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="240px" height="100px" version="1.1" overflow="visible">
+  <g id="background" role="group" fill="#ffffff">
+    <path d="M-4.2961 24.1741 L-4.2961 110.465 L90.2186 110.465 L90.2186 24.1741 L-4.2961 24.1741 Z"/>
+  </g>
+</svg>
+`
+
+export {SIMPLE_CSS, SIMPLE_SVG, SVG_WITH_UNMAPPED_ELEMENTS, SVG_WITH_WIDTH_AND_HEIGHT_BUT_NO_VIEWPORT}

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -1,5 +1,5 @@
 import parser, { parseSvg, makeCssAst} from '../parser'
-import {SIMPLE_CSS, SIMPLE_SVG} from './fixtures.test'
+import {SIMPLE_CSS, SIMPLE_SVG, SVG_WITH_WIDTH_AND_HEIGHT_BUT_NO_VIEWPORT} from './fixtures.test'
 
 describe('svg-parser main lib', () => {
   it('should parse css and return a set of rules', () => {
@@ -62,6 +62,13 @@ describe('svg-parser main lib', () => {
     expect(svg).toBeTruthy()
     const { viewBox } = svg.props
     expect(viewBox).toBe('0 0 200 100')
+  })
+
+  it('should format an SVG with a viewBox from the height and width of the SVG', () => {
+    const svg = parser(SVG_WITH_WIDTH_AND_HEIGHT_BUT_NO_VIEWPORT, SIMPLE_CSS)
+    expect(svg).toBeTruthy()
+    const { viewBox } = svg.props
+    expect(viewBox).toBe('0 0 240 100')
   })
 
   it('handles text elements', () => {

--- a/src/converter.js
+++ b/src/converter.js
@@ -56,6 +56,16 @@ function extractViewbox (markup) {
   }
 }
 
+function extractWidthAndHeight (markup) {
+  let width = markup.attributes ? Object.values(markup.attributes).filter((attr) => attr.name === 'width')[0] : false
+  let height = markup.attributes ? Object.values(markup.attributes).filter((attr) => attr.name === 'height')[0] : false
+
+  width = width ? width.value.replace('px', '') : width
+  height = height ? height.value.replace('px', '') : height
+
+  return [width, height]
+}
+
 function getCssRulesForAttr (attr, cssRules) {
   let rules = []
   if (attr.name === 'id') {
@@ -149,6 +159,8 @@ function traverse (markup, config, i = 0) {
   let attrs = []
   if (tagName === 'svg') {
     const viewBox = extractViewbox(markup)
+    const [width, height] = extractWidthAndHeight(markup)
+
     attrs.push({
       name: 'width',
       value: config.width || viewBox.width
@@ -159,7 +171,7 @@ function traverse (markup, config, i = 0) {
     })
     attrs.push({
       name: 'viewBox',
-      value: config.viewBox || viewBox.viewBox || '0 0 50 50'
+      value: config.viewBox || viewBox.viewBox || `0 0 ${width || 50} ${height || 50}`
     })
   } else {
     // otherwise, if not SVG, check to see if there is CSS to apply.


### PR DESCRIPTION
Some SVG seems to have a height and width defined in the SVG tag. This pull request try to use those dimensions when calculating a missing ViewBox

A example of such svg is: https://haveibeenpwned.com/Content/Images/PwnedLogos/Disqus.svg